### PR TITLE
TTY IO Improvement

### DIFF
--- a/sr_port/gbldefs.c
+++ b/sr_port/gbldefs.c
@@ -1482,4 +1482,11 @@ GBLDEF gdr_name	*gdr_name_head;
 GBLDEF gd_addr	*gd_addr_head;
 
 GBLDEF	boolean_t	shebang_invocation;	/* TRUE if yottadb is invoked through the "ydbsh" (YDBSH macro) soft link */
+GBLDEF	block_id	mu_upgrade_pin_blkarray[MAX_BT_DEPTH + 1]; /* List of block numbers that "mupip upgrade" wants pinned. Used
+								    * by "db_csh_getn()" to ensure these blocks do not get reused.
+								    * Note that this is different from "cw_stagnate" in that the
+								    * latter hash table is reinitialized after every "t_end()" or
+								    * "t_abort()" call whereas "mu_upgrade_pin_blkarray[]" is not.
+								    */
+GBLDEF	int		mu_upgrade_pin_blkarray_idx;	/* Index into the next available slot in mu_upgrade_pin_blkarray[] */
 

--- a/sr_port/gvcst_root_search.c
+++ b/sr_port/gvcst_root_search.c
@@ -268,7 +268,9 @@ enum cdb_sc gvcst_root_search(boolean_t donot_restart)
 		reset_gv_target = save_targ;
 	}
 	T_BEGIN_READ_NONTP_OR_TP(ERR_GVGETFAIL);
-	/* We better hold crit in the final retry (TP & non-TP). Only exception is journal recovery */
+	/* We better hold crit in the final retry (TP & non-TP).
+	 * Only exceptions are journal recovery or mupip upgrade both of which hold standalone access.
+	 */
 	assert((t_tries < CDB_STAGNATE) || cs_addrs->now_crit
 		|| mupip_jnl_recover || (MUPIP_UPGRADE_IN_PROGRESS == mu_upgrade_in_prog));
 	for (;;)

--- a/sr_unix/generic_signal_handler.c
+++ b/sr_unix/generic_signal_handler.c
@@ -364,7 +364,8 @@ void generic_signal_handler(int sig, siginfo_t *info, void *context, boolean_t i
 						assert(!IS_GTMSECSHR_IMAGE);
 						if (exit_handler_active && !ydb_quiet_halt)
 							SEND_AND_PUT_MSG(VARLSTCNT(1) forced_exit_err);
-						return;
+						DECREMENT_IN_OS_SIGNAL_HANDLER_IF_NEEDED;
+						CLEANUP_AND_RETURN(got_tlevel_lock);
 					}
 				}
 				DEBUG_ONLY(in_nondeferrable_signal_handler = IN_GENERIC_SIGNAL_HANDLER);


### PR DESCRIPTION
- corrected issue whereby IO state was not properly maintained between commands
- corrected issue where NOECHO was not working properly
- added functionality such that with ESCAPE processing ON, if user types isolated ESC, then 100 ms timeout allows return of isolated ESC rather than hanging IO waiting for rest of non-existent escape sequence
- Worked to optimize TTY code readability, simplifying some boolean logic through #define MACROS